### PR TITLE
Update emsgetinfo.inc

### DIFF
--- a/includes/emsgetinfo.inc
+++ b/includes/emsgetinfo.inc
@@ -142,6 +142,7 @@ function getContactInfo($src){
   $out = array();
   foreach($res as $l){
     if ($l!="OK\n") $out[] = trim($l);
+    if ($l="OK\n") $out[1] = trim($l);
   }
   return $out[$src-1];;  
 }


### PR DESCRIPTION
quick and dirty hack um die Fehlermeldung "FastCGI-stderr: PHP Notice:  Undefined offset: 1 in /opt/ems-tools/includes/emsgetinfo.inc on line 146", beim Aufruf der erweiterten Einstellungen zu verhindern, wenn "contact2" leer ist
